### PR TITLE
Implementing Logic to Produce a 12-Year Forecast Calculation Based on Multipliers or 3-Year Averages

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,7 +96,7 @@ model FinancialCompilation {
     totalCurrentAssets        Int
     propertyPlantAndEquipment Int
     investment                Int
-    totalLongTermAsset        Int
+    totalLongTermAssets        Int
     accountsPayable           Int
     longDebtService           Int
     taxesPayable              Int

--- a/src/app/api/financial-compilation/route.ts
+++ b/src/app/api/financial-compilation/route.ts
@@ -32,7 +32,6 @@ export async function POST(req: Request) {
 
     const dbData = {
       companyId: user.companyId,
-      year,
       userId,
       ...calculated,
     };

--- a/src/app/queries/financial-comp/financial-calculations.ts
+++ b/src/app/queries/financial-comp/financial-calculations.ts
@@ -1,4 +1,5 @@
 export interface AuditorData {
+  year: number;
   // Basic Income Statement values
   revenue: number;
   costOfContracting: number;
@@ -13,6 +14,7 @@ export interface AuditorData {
   otherIncome: number;
   incomeTaxes: number;
 
+  // Basic Balance Sheet values
   // Basic Balance Sheet values
   cashAndCashEquivalents: number;
   accountsReceivable: number;
@@ -29,6 +31,7 @@ export interface AuditorData {
 }
 
 export interface FinancialCompilation {
+  year: number;
   // Income Statement values
   revenue: number;
   costOfContracting: number;
@@ -71,7 +74,7 @@ export interface FinancialCompilation {
   equityCapital: number;
   retainedEarnings: number;
   totalCurrentAssets: number;
-  totalLongTermAsset: number;
+  totalLongTermAssets: number;
   totalAssets: number;
   totalCurrentLiabilities: number;
   totalLongTermLiabilities: number;
@@ -101,8 +104,8 @@ export const calculateFinancialCompilation = (data: AuditorData): FinancialCompi
 
   // Calculating Balance Sheet values
   const totalCurrentAssets = data.cashAndCashEquivalents + data.accountsReceivable + data.inventory;
-  const totalLongTermAsset = data.propertyPlantAndEquipment + data.investment;
-  const totalAssets = totalCurrentAssets + totalLongTermAsset;
+  const totalLongTermAssets = data.propertyPlantAndEquipment + data.investment;
+  const totalAssets = totalCurrentAssets + totalLongTermAssets;
   const totalCurrentLiabilities = data.accountsPayable + data.currentDebtService + data.taxesPayable;
   const totalLongTermLiabilities = data.longDebtService + data.loansPayable;
   const totalLiabilities = totalCurrentLiabilities + totalLongTermLiabilities;
@@ -110,6 +113,7 @@ export const calculateFinancialCompilation = (data: AuditorData): FinancialCompi
   const totalLiabilitiesAndEquity = totalLiabilities + totalStockholdersEquity;
 
   const FinComp: FinancialCompilation = {
+    year: data.year,
     // Income Statement Values
     revenue: data.revenue,
     costOfContracting: data.costOfContracting,
@@ -152,7 +156,7 @@ export const calculateFinancialCompilation = (data: AuditorData): FinancialCompi
     equityCapital: data.equityCapital,
     retainedEarnings: data.retainedEarnings,
     totalCurrentAssets,
-    totalLongTermAsset,
+    totalLongTermAssets,
     totalAssets,
     totalCurrentLiabilities,
     totalLongTermLiabilities,

--- a/src/app/queries/financial-comp/tests/financial-test.ts
+++ b/src/app/queries/financial-comp/tests/financial-test.ts
@@ -1,0 +1,193 @@
+import { calculateFinancialCompilation } from '../financial-calculations';
+
+interface FinancialCompilation {
+  year: number;
+  // Needed for Income Statement values
+  revenue: number;
+  costOfContracting: number;
+  overhead: number;
+  salariesAndBenefits: number;
+  rentAndOverhead: number;
+  depreciationAndAmortization: number;
+  interest: number;
+  interestIncome: number;
+  interestExpense: number;
+  gainOnDisposalOfAssets: number;
+  otherIncome: number;
+  incomeTaxes: number;
+
+  // Needed for Balance Sheet values
+  cashAndCashEquivalents: number;
+  accountsReceivable: number;
+  inventory: number;
+  propertyPlantAndEquipment: number;
+  investment: number;
+  accountsPayable: number;
+  taxesPayable: number;
+  currentDebtService: number;
+  loansPayable: number;
+  longDebtService: number;
+  equityCapital: number;
+  retainedEarnings: number;
+
+  netSales: number;
+  costOfGoodsSold: number;
+  totalOperatingExpenses: number;
+  totalOtherIncome: number;
+  grossProfit: number;
+  grossMarginPercentage: number;
+  operatingExpensesPercentage: number;
+  totalOtherIncomePercentage: number;
+  profitFromOperations: number;
+  incomeBeforeIncomeTaxes: number;
+  pretaxIncomePercentage : number;
+  netIncome: number;
+  profitFromOperationsPercentage: number;
+  netIncomePercentage: number;
+
+  totalCurrentAssets: number;
+  totalLongTermAssets: number;
+  totalAssets: number;
+  totalCurrentLiabilities: number;
+  totalLongTermLiabilities: number;
+  totalLiabilities: number;
+  totalStockholdersEquity: number;
+  totalLiabilitiesAndEquity: number;
+}
+
+// Data from the spreadsheet
+const AuditorData2022 = {
+  year: 2022,
+  revenue: 131345,
+  costOfContracting: 48456,
+  overhead: 667,
+  salariesAndBenefits: 23872,
+  rentAndOverhead: 10087,
+  depreciationAndAmortization: 17205,
+  interest: 1500,
+  interestIncome: 0,
+  interestExpense: 0,
+  gainOnDisposalOfAssets: 0,
+  otherIncome: 0,
+  incomeTaxes: 8483,
+  cashAndCashEquivalents: 183715,
+  accountsReceivable: 6567,
+  inventory: 9825,
+  propertyPlantAndEquipment: 40145,
+  investment: 0,
+  accountsPayable: 4912,
+  currentDebtService: 5000,
+  taxesPayable: 4265,
+  longDebtService: 15000,
+  loansPayable: 20000,
+  equityCapital: 170000,
+  retainedEarnings: 21075,
+};
+
+const AuditorData2023 = {
+  year: 2023,
+  revenue: 142341,
+  costOfContracting: 52587,
+  overhead: 667,
+  salariesAndBenefits: 23002,
+  rentAndOverhead: 10020,
+  depreciationAndAmortization: 16544,
+  interest: 900,
+  interestIncome: 0,
+  interestExpense: 0,
+  gainOnDisposalOfAssets: 0,
+  otherIncome: 0,
+  incomeTaxes: 10908,
+  cashAndCashEquivalents: 191069,
+  accountsReceivable: 7117,
+  inventory: 10531,
+  propertyPlantAndEquipment: 38602,
+  investment: 20000,
+  accountsPayable: 5265,
+  currentDebtService: 5000,
+  taxesPayable: 5341,
+  longDebtService: 15000,
+  loansPayable: 40000,
+  equityCapital: 170000,
+  retainedEarnings: 26713,
+};
+
+const AuditorData2024 = {
+  year: 2024,
+  revenue: 150772,
+  costOfContracting: 7539,
+  overhead: 11342,
+  salariesAndBenefits: 56643,
+  rentAndOverhead: 667,
+  depreciationAndAmortization: 25245,
+  interest: 11412,
+  interestIncome: 16080,
+  interestExpense: 900,
+  gainOnDisposalOfAssets: 0,
+  otherIncome: 0,
+  incomeTaxes: 11598,
+  cashAndCashEquivalents: 189550,
+  accountsReceivable: 7539,
+  inventory: 11342,
+  propertyPlantAndEquipment: 37521,
+  investment: 50000,
+  accountsPayable: 5671,
+  currentDebtService: 5000,
+  taxesPayable: 2054,
+  longDebtService: 15000,
+  loansPayable: 70000,
+  equityCapital: 170000,
+  retainedEarnings: 28227,
+};
+
+const printResults = (result: any, year: string) => {
+  console.log(`\nResults for ${year}:`);
+  console.log('Income Statement:');
+  console.log(`Net Sales: ${result.netSales}`);
+
+  console.log(`Cost of Goods Sold: ${result.costOfGoodsSold}`);
+  console.log(`Gross Profit: ${result.grossProfit}`);
+  console.log(`Gross Margin Percentage: ${result.grossMarginPercentage}`);
+
+  console.log(`Total Operating Expenses: ${result.totalOperatingExpenses}`);
+  console.log(`Operating Expenses Percentage: ${result.operatingExpensesPercentage}`);
+  console.log(`Profit From Operations: ${result.profitFromOperations}`);
+  console.log(`Profit From Operations Percentage: ${result.profitFromOperationsPercentage}`);
+
+  console.log(`Total Other Income: ${result.totalOtherIncome}`);
+  console.log(`Total Other Income Percentage: ${result.totalOtherIncomePercentage}`);
+  console.log(`Income Before Income Taxes: ${result.incomeBeforeIncomeTaxes}`);
+  console.log(`Pre-tax Income Percentage: ${result.pretaxIncomePercentage}`);
+
+  console.log(`Net Income: ${result.netIncome}`);
+  console.log(`Net Income Percentage: ${result.netIncomePercentage}`);
+
+  console.log('\nBalance Sheet:');
+  console.log(`Total Current Assets: ${result.totalCurrentAssets}`);
+  console.log(`Total Long-Term Asset: ${result.totalLongTermAssets}`);
+  console.log(`Total Assets: ${result.totalAssets}`);
+  console.log(`Total Current Liabilities: ${result.totalCurrentLiabilities}`);
+  console.log(`Total Long-Term Liabilities: ${result.totalLongTermLiabilities}`);
+  console.log(`Total Liabilities: ${result.totalLiabilities}`);
+  console.log(`Total Stockholders Equity: ${result.totalStockholdersEquity}`);
+  console.log(`Total Liabilities and Equity: ${result.totalLiabilitiesAndEquity}`);
+};
+
+const runMultiForecastTests = (): FinancialCompilation => {
+  const result2024 = calculateFinancialCompilation(AuditorData2024);
+  return result2024;
+};
+
+const runFinCompTests = () => {
+  const result2022 = calculateFinancialCompilation(AuditorData2022);
+  const result2023 = calculateFinancialCompilation(AuditorData2023);
+  const result2024 = calculateFinancialCompilation(AuditorData2024);
+
+  printResults(result2022, '2022');
+  printResults(result2023, '2023');
+  printResults(result2024, '2024');
+};
+
+export default runMultiForecastTests;
+// runTests()
+runFinCompTests();

--- a/src/app/queries/forecasts/calculate-forecast.ts
+++ b/src/app/queries/forecasts/calculate-forecast.ts
@@ -1,0 +1,12 @@
+// src/app/queries/forecasts/calculate-forecast.ts
+
+export function calculateAverageForecast(pastValues: number[]): number {
+  if (pastValues.length === 0) return 0;
+  return pastValues.reduce((sum, value) => sum + value, 0) / pastValues.length;
+}
+
+export function calculateMultiplierForecast(pastValues: number[], multiplier: number): number {
+  if (pastValues.length === 0) return 0;
+  const lastPastValue = pastValues[pastValues.length - 1]; // Get the latest year value
+  return lastPastValue * (1 + multiplier); // Apply the multiplier (adds a percentage increase)
+}

--- a/src/app/queries/forecasts/forecast.ts
+++ b/src/app/queries/forecasts/forecast.ts
@@ -1,0 +1,70 @@
+import { calculateAverageForecast, calculateMultiplierForecast } from './calculate-forecast';
+
+type FinancialData = {
+  year: number;
+  revenue: number;
+  costOfContracting: number;
+  overhead: number;
+  salariesAndBenefits: number;
+  rentAndOverhead: number;
+  depreciationAndAmortization: number;
+  interest: number;
+  profitFromOperations: number;
+  interestIncome: number;
+  interestExpense: number;
+  gainOnDisposalOfAssets: number;
+  otherIncome: number;
+  incomeTaxes: number;
+  cashAndCashEquivalents: number;
+  accountsReceivable: number;
+  inventory: number;
+  propertyPlantAndEquipment: number;
+  investment: number;
+  accountsPayable: number;
+  taxesPayable: number;
+  currentDebtService: number;
+  loansPayable: number;
+  longDebtService: number;
+  equityCapital: number;
+  retainedEarnings: number;
+};
+
+type ForecastMethod = 'average' | 'multiplier';
+
+type ForecastSettings = Record<keyof Omit<FinancialData, 'year'>, ForecastMethod>;
+
+type ForecastResult = FinancialData[];
+
+export default function generateForecast(
+  pastData: FinancialData[],
+  settings: ForecastSettings,
+  multiplierValues: Record<keyof Omit<FinancialData, 'year'>, number>,
+): ForecastResult {
+  const lastYear = pastData[pastData.length - 1].year;
+  const forecast: ForecastResult = [];
+
+  for (let i = 1; i <= 12; i++) {
+    const year = lastYear + i;
+    const forecastEntry: FinancialData = { year } as FinancialData;
+
+    // rolling window
+    const currentData = [...pastData, ...forecast];
+
+    for (const field of Object.keys(settings) as (keyof Omit<FinancialData, 'year'>)[]) {
+      const method = settings[field];
+
+      // last 3 years
+      const pastValues = currentData
+        .map(entry => entry[field])
+        .slice(-3);
+
+      forecastEntry[field] = method === 'average'
+        ? calculateAverageForecast(pastValues)
+        : calculateMultiplierForecast(pastValues, multiplierValues[field]);
+    }
+
+    forecast.push(forecastEntry);
+  }
+
+  return forecast;
+}

--- a/src/app/queries/forecasts/tests/forecast-tests.ts
+++ b/src/app/queries/forecasts/tests/forecast-tests.ts
@@ -1,0 +1,212 @@
+import generateForecast from '../forecast';
+
+const FinancialData2022 = {
+  revenue: 131345,
+  costOfContracting: 48456,
+  overhead: 667,
+  salariesAndBenefits: 23872,
+  rentAndOverhead: 10087,
+  depreciationAndAmortization: 17205,
+  interest: 1500,
+  profitFromOperations: 29558,
+  interestIncome: 0,
+  interestExpense: 0,
+  gainOnDisposalOfAssets: 0,
+  otherIncome: 0,
+  incomeTaxes: 8483,
+  cashAndCashEquivalents: 183715,
+  accountsReceivable: 6567,
+  inventory: 9825,
+  propertyPlantAndEquipment: 40145,
+  investment: 0,
+  accountsPayable: 4912,
+  currentDebtService: 5000,
+  taxesPayable: 4265,
+  longDebtService: 15000,
+  loansPayable: 20000,
+  equityCapital: 170000,
+  retainedEarnings: 21075,
+};
+
+const FinancialData2023 = {
+  revenue: 142341,
+  costOfContracting: 52587,
+  overhead: 667,
+  salariesAndBenefits: 23002,
+  rentAndOverhead: 11020,
+  depreciationAndAmortization: 16544,
+  interest: 900,
+  profitFromOperations: 37621,
+  interestIncome: 0,
+  interestExpense: 0,
+  gainOnDisposalOfAssets: 0,
+  otherIncome: 0,
+  incomeTaxes: 10908,
+  cashAndCashEquivalents: 191069,
+  accountsReceivable: 7117,
+  inventory: 10531,
+  propertyPlantAndEquipment: 38602,
+  investment: 20000,
+  accountsPayable: 5265,
+  currentDebtService: 5000,
+  taxesPayable: 5341,
+  longDebtService: 15000,
+  loansPayable: 40000,
+  equityCapital: 170000,
+  retainedEarnings: 26713,
+};
+
+const FinancialData2024 = {
+  revenue: 150772,
+  costOfContracting: 56643,
+  overhead: 667,
+  salariesAndBenefits: 25245,
+  rentAndOverhead: 11412,
+  depreciationAndAmortization: 16080,
+  interest: 900,
+  profitFromOperations: 39825,
+  interestIncome: 0,
+  interestExpense: 0,
+  gainOnDisposalOfAssets: 0,
+  otherIncome: 0,
+  incomeTaxes: 11598,
+  cashAndCashEquivalents: 189550,
+  accountsReceivable: 7539,
+  inventory: 11342,
+  propertyPlantAndEquipment: 37521,
+  investment: 50000,
+  accountsPayable: 5671,
+  currentDebtService: 5000,
+  taxesPayable: 2054,
+  longDebtService: 15000,
+  loansPayable: 70000,
+  equityCapital: 170000,
+  retainedEarnings: 28227,
+};
+
+const pastData = [
+  { year: 2022, ...FinancialData2022 },
+  { year: 2023, ...FinancialData2023 },
+  { year: 2024, ...FinancialData2024 },
+];
+
+// Define the ForecastMethod type
+type ForecastMethod = 'average' | 'multiplier';
+
+// Define the ForecastSettings interface
+interface ForecastSettings {
+  revenue: ForecastMethod;
+  costOfContracting: ForecastMethod;
+  overhead: ForecastMethod;
+  salariesAndBenefits: ForecastMethod;
+  rentAndOverhead: ForecastMethod;
+  depreciationAndAmortization: ForecastMethod;
+  interest: ForecastMethod;
+  profitFromOperations: ForecastMethod;
+  interestIncome: ForecastMethod;
+  interestExpense: ForecastMethod;
+  gainOnDisposalOfAssets: ForecastMethod;
+  otherIncome: ForecastMethod;
+  incomeTaxes: ForecastMethod;
+  cashAndCashEquivalents: ForecastMethod;
+  accountsReceivable: ForecastMethod;
+  inventory: ForecastMethod;
+  propertyPlantAndEquipment: ForecastMethod;
+  investment: ForecastMethod;
+  accountsPayable: ForecastMethod;
+  taxesPayable: ForecastMethod;
+  currentDebtService: ForecastMethod;
+  loansPayable: ForecastMethod;
+  longDebtService: ForecastMethod;
+  equityCapital: ForecastMethod;
+  retainedEarnings: ForecastMethod;
+}
+
+// Example of creating forecast settings
+const settings: ForecastSettings = {
+  revenue: 'multiplier',
+  costOfContracting: 'average',
+  overhead: 'average',
+  salariesAndBenefits: 'average',
+  rentAndOverhead: 'average',
+  depreciationAndAmortization: 'average',
+  interest: 'average',
+  profitFromOperations: 'average',
+  interestIncome: 'average',
+  interestExpense: 'average',
+  gainOnDisposalOfAssets: 'average',
+  otherIncome: 'average',
+  incomeTaxes: 'average',
+  cashAndCashEquivalents: 'average',
+  accountsReceivable: 'average',
+  inventory: 'average',
+  propertyPlantAndEquipment: 'average',
+  investment: 'average',
+  accountsPayable: 'average',
+  taxesPayable: 'average',
+  currentDebtService: 'average',
+  loansPayable: 'average',
+  longDebtService: 'average',
+  equityCapital: 'average',
+  retainedEarnings: 'average',
+};
+
+type FinancialData = {
+  revenue: number;
+  costOfContracting: number;
+  overhead: number;
+  salariesAndBenefits: number;
+  rentAndOverhead: number;
+  depreciationAndAmortization: number;
+  interest: number;
+  profitFromOperations: number;
+  interestIncome: number;
+  interestExpense: number;
+  gainOnDisposalOfAssets: number;
+  otherIncome: number;
+  incomeTaxes: number;
+  cashAndCashEquivalents: number;
+  accountsReceivable: number;
+  inventory: number;
+  propertyPlantAndEquipment: number;
+  investment: number;
+  accountsPayable: number;
+  taxesPayable: number;
+  currentDebtService: number;
+  loansPayable: number;
+  longDebtService: number;
+  equityCapital: number;
+  retainedEarnings: number;
+};
+
+const multiplierValues: Record<keyof Omit<FinancialData, 'year'>, number> = {
+  revenue: 0.015,
+  costOfContracting: 0,
+  overhead: 0,
+  salariesAndBenefits: 0,
+  rentAndOverhead: 0,
+  depreciationAndAmortization: 0,
+  interest: 0,
+  profitFromOperations: 0,
+  interestIncome: 0,
+  interestExpense: 0,
+  gainOnDisposalOfAssets: 0,
+  otherIncome: 0,
+  incomeTaxes: 0,
+  cashAndCashEquivalents: 0,
+  accountsReceivable: 0,
+  inventory: 0,
+  propertyPlantAndEquipment: 0,
+  investment: 0,
+  accountsPayable: 0,
+  taxesPayable: 0,
+  currentDebtService: 0,
+  loansPayable: 0,
+  longDebtService: 0,
+  equityCapital: 0,
+  retainedEarnings: 0,
+};
+
+const forecastResult = generateForecast(pastData, settings, multiplierValues);
+
+console.log('Forecast Results:', forecastResult);


### PR DESCRIPTION
## Summary:

This pull adds the logic for calculating a 12-year multiplier/3-year average forecast.
 
## Changes:

- Three new files: `forecast.ts`, `calculate-forecasts.ts` and `forecast-tests.ts`
  - `forecast.ts`: Handles the main logic for generating a forecast.
  - `calculate-forecast.ts`: Used to calculate the multiplier and 3-year average values.
  - `forecast-tests.ts`: Used to test and ensure the accuracy of `forecast.ts` and `calculate-forecast.ts`.
 
## Notes:

- There is no implementation for saving the data to the database
- Using `forecast-tests.ts`
  1. cd into src\app\queries\forecasts\tests\forecast-tests.ts
  2. `npx tsc forecast-tests.ts`
  3. `node forecast-tests.js`
  
Closes #105 - Implement a 12-Year Forecast Calculation Based on Multipliers or 3-Year Averages.
